### PR TITLE
adding the renormed skymap contour calculation event tool method

### DIFF
--- a/src/gwtm_api/event_tools.py
+++ b/src/gwtm_api/event_tools.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, List, Tuple
 import ligo.skymap.plot  # noqa: F401
 from matplotlib import pyplot as plt
@@ -8,6 +9,7 @@ import astropy
 
 import healpy as hp
 from ligo.skymap.postprocess.util import find_greedy_credible_levels
+import ligo.skymap.postprocess
 
 from . import Pointing, Instrument, Footprint, Candidate
 from .alert import Alert as Alert
@@ -307,6 +309,35 @@ def renormalize_skymap(api_token: str, graceid: str, pointings: List[Pointing] =
     normed_skymap = skymap/np.sum(skymap)
 
     return normed_skymap
+
+def renormed_skymap_contours(api_token: str, graceid: str, pointings: List[Pointing] = [],
+    cache=False) -> Any:
+
+    normed_skymap = renormalize_skymap(api_token=api_token, graceid=graceid, pointings=pointings, cache=cache)
+
+    i = np.flipud(np.argsort(normed_skymap))
+    cumsum = np.cumsum(normed_skymap[i])
+    cls = np.empty_like(normed_skymap)
+    cls[i] = cumsum * 100
+    paths = list(ligo.skymap.postprocess.contour(cls, [50, 90], nest=True, degrees=True, simplify=True))
+
+    contours_json = json.dumps({
+        'type': 'FeatureCollection',
+        'features': [
+            {
+                'type': 'Feature',
+                'properties': {
+                    'credible_level': contour
+                },
+                'geometry': {
+                    'type': 'MultiLineString',
+                    'coordinates': path
+                }
+            }
+            for contour, path in zip([50,90], paths)
+        ]
+    })
+    return contours_json
 
 
 def candidate_coverage(api_token: str, candidate: Candidate, pointings: List[Pointing] = None, distance_thresh: float = 5.0) -> List[Pointing]:

--- a/src/gwtm_api/event_tools.py
+++ b/src/gwtm_api/event_tools.py
@@ -319,7 +319,7 @@ def renormed_skymap_contours(api_token: str, graceid: str, pointings: List[Point
     cumsum = np.cumsum(normed_skymap[i])
     cls = np.empty_like(normed_skymap)
     cls[i] = cumsum * 100
-    paths = list(ligo.skymap.postprocess.contour(cls, [50, 90], nest=True, degrees=True, simplify=True))
+    paths = list(ligo.skymap.postprocess.contour(cls, [50, 90], nest=False, degrees=True, simplify=True))
 
     contours_json = json.dumps({
         'type': 'FeatureCollection',


### PR DESCRIPTION
added the functionality to calculate the contours based on a renormalized skymap.

```python
from gwtm_api.event_tools import renormed_skymap_contours

contours_json = renormed_skymap_contours(
    api_token=API_TOKEN, graceid=GRACE_ID, pointings=POINTINGS_LIST
)
```

The contours_json can then be used to redraw the aladin lite visualization on the gwtm app.